### PR TITLE
feat(cwg-2026): add medal tally and refine schedule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indianolympicdream",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.js --host 0.0.0.0",

--- a/src/app/games/cwg-2026-home.component.html
+++ b/src/app/games/cwg-2026-home.component.html
@@ -25,26 +25,77 @@
       </div>
     </div>
 
-    <div class="hero-stats">
-      <div class="stat-box">
-        <strong>{{ summary().athletes }}</strong>
-        <span>Athletes ({{ summary().ableAthletes }} Able · {{ summary().paraAthletes }} Para)</span>
+    <section class="hero-medal-tally" aria-labelledby="india-medal-tally-title">
+      <div class="medal-tally-header">
+        <div class="medal-tally-title">
+          <span>Official results</span>
+          <strong id="india-medal-tally-title">India Medal Tally</strong>
+          <small>{{ medalStreamLabel() }}</small>
+        </div>
+
+        <div class="medal-tally-controls">
+          <div class="medal-stream-filter" role="group" aria-label="Filter India medal tally">
+            <button *ngFor="let filter of medalStreamFilters" type="button"
+              [class.active]="selectedMedalStream() === filter.key"
+              [attr.aria-pressed]="selectedMedalStream() === filter.key"
+              (click)="setMedalStream(filter.key)">
+              {{ filter.label }}
+            </button>
+          </div>
+        </div>
       </div>
-      <div class="stat-box">
-        <strong>{{ summary().sports }}</strong>
-        <span>Sports ({{ summary().ableSports }} Able · {{ summary().paraSports }} Para)</span>
+
+      <div class="medal-scoreboard" role="table" aria-label="India medal tally" aria-live="polite">
+        <div class="medal-scoreboard-head" role="row">
+          <span role="columnheader">Rank</span>
+          <span role="columnheader">Nation</span>
+          <span role="columnheader">Gold</span>
+          <span role="columnheader">Silver</span>
+          <span role="columnheader">Bronze</span>
+          <span role="columnheader">Total</span>
+        </div>
+
+        <div class="medal-scoreboard-row" role="row">
+          <strong class="india-rank" role="cell" aria-label="India overall rank">
+            <span>#{{ indiaRank() || '—' }}</span>
+            <small>Overall</small>
+          </strong>
+          <div class="medal-nation" role="rowheader">
+            <span class="india-flag" aria-hidden="true">🇮🇳</span>
+            <span>
+              <strong>India</strong>
+              <small>IND</small>
+            </span>
+          </div>
+          <strong class="medal-number gold" role="cell" aria-label="Gold medals">
+            <img [src]="medalIconUrl" alt="">
+            <span>{{ medalTally().gold }}</span>
+          </strong>
+          <strong class="medal-number silver" role="cell" aria-label="Silver medals">
+            <img [src]="silverMedalIconUrl" alt="">
+            <span>{{ medalTally().silver }}</span>
+          </strong>
+          <strong class="medal-number bronze" role="cell" aria-label="Bronze medals">
+            <img [src]="bronzeMedalIconUrl" alt="">
+            <span>{{ medalTally().bronze }}</span>
+          </strong>
+          <strong class="medal-number total" role="cell" aria-label="Total medals">{{ medalTally().total }}</strong>
+        </div>
       </div>
-      <div class="stat-box gold">
-        <strong>{{ summary().golds }}</strong>
-        <span>Gold medal events mapped</span>
+
+      <div class="medal-tally-footer">
+        <span>Declared medals only</span>
+        <div class="medal-tally-actions">
+          <button *ngIf="liveCount() > 0" type="button" class="medal-results-action has-live"
+            (click)="openHeaderLivePanel()" aria-label="Show live sessions for India">
+            <span><i class="pulse-dot"></i>{{ liveCount() }} live</span>
+          </button>
+          <button type="button" class="medal-winners-action" (click)="openMedalWinnersDialog()">
+            View {{ medalTally().total }} medal winners <span aria-hidden="true">→</span>
+          </button>
+        </div>
       </div>
-      <button type="button" class="stat-box live-stat header-live-control" [class.has-live]="liveCount() > 0"
-        (click)="openHeaderLivePanel()"
-        [attr.aria-label]="liveCount() > 0 ? 'Show live sessions for India' : 'View declared results'">
-        <strong>{{ liveCount() || declaredResults().length }}</strong>
-        <span>{{ liveCount() > 0 ? 'Live now' : 'Results logged' }}</span>
-      </button>
-    </div>
+    </section>
   </header>
 
   <!-- Core Answer Grid -->
@@ -336,16 +387,23 @@
     </div>
   </section>
 
-  <div class="home-session-dialog" *ngIf="selectedSessionRow() as row" role="presentation"
+  <div class="home-session-dialog result-session-dialog" *ngIf="selectedSessionRow() as row" role="presentation"
     (click)="closeSessionDialog()">
     <aside class="home-session-panel" role="dialog" aria-modal="true" aria-label="Session details"
       (click)="$event.stopPropagation()">
       <header class="home-session-header">
-        <div class="next-sport">
-          <span class="sport-icon" *ngIf="getSchedulePictogramUrl(row) as pictogram">
-            <img [src]="pictogram" [alt]="row.sport">
-          </span>
-          <span>{{ row.sport }}</span>
+        <div class="home-session-heading">
+          <button *ngIf="resultOpenedFromMedalWinners()" class="home-dialog-back" type="button"
+            (click)="backToMedalWinners()" aria-label="Back to medal winners">
+            <span aria-hidden="true">←</span>
+            <span>Medal winners</span>
+          </button>
+          <div class="next-sport">
+            <span class="sport-icon" *ngIf="getSchedulePictogramUrl(row) as pictogram">
+              <img [src]="pictogram" [alt]="row.sport">
+            </span>
+            <span>{{ row.sport }}</span>
+          </div>
         </div>
         <button class="home-dialog-close" type="button" aria-label="Close details"
           (click)="closeSessionDialog()">&times;</button>
@@ -408,6 +466,53 @@
           </span>
           <span class="live-session-arrow" aria-hidden="true">›</span>
         </button>
+      </div>
+    </aside>
+  </div>
+
+  <div class="home-session-dialog" *ngIf="isMedalWinnersDialogOpen()" role="presentation"
+    (click)="closeMedalWinnersDialog()">
+    <aside class="home-session-panel medal-winners-panel" role="dialog" aria-modal="true"
+      aria-labelledby="medal-winners-title" (click)="$event.stopPropagation()">
+      <header class="home-session-header">
+        <div class="medal-winners-title">
+          <span class="india-flag" aria-hidden="true">🇮🇳</span>
+          <div>
+            <strong id="medal-winners-title">India’s medal winners</strong>
+            <small>{{ medalStreamLabel() }} · {{ visibleMedalWinners().length }} medals</small>
+          </div>
+        </div>
+        <button class="home-dialog-close" type="button" aria-label="Close medal winners"
+          (click)="closeMedalWinnersDialog()">&times;</button>
+      </header>
+
+      <div class="home-session-body medal-winners-list">
+        <div class="medal-sport-filters" role="group" aria-label="Filter medal winners by sport">
+          <button type="button" *ngFor="let sport of medalSportFilters()"
+            [class.active]="selectedMedalSport() === sport.key"
+            [attr.aria-pressed]="selectedMedalSport() === sport.key"
+            (click)="setMedalSport(sport.key)">
+            <span>{{ sport.label }}</span>
+            <strong>{{ sport.count }}</strong>
+          </button>
+        </div>
+
+        <button class="medal-winner-row" type="button" *ngFor="let winner of visibleMedalWinners()"
+          (click)="openMedalWinnerDetails(winner)">
+          <img [src]="getMedalIconUrl(winner.type)" [alt]="getMedalLabel(winner.type) + ' medal'">
+          <span class="medal-winner-copy">
+            <span>{{ winner.sport }} · {{ getMedalLabel(winner.type) }}</span>
+            <strong>{{ winner.athleteName }}</strong>
+            <small>
+              {{ winner.event }}<ng-container *ngIf="winner.result"> · {{ winner.result }}</ng-container>
+            </small>
+          </span>
+          <span class="live-session-arrow" aria-hidden="true">›</span>
+        </button>
+
+        <p class="medal-winners-empty" *ngIf="visibleMedalWinners().length === 0">
+          No declared medals in this category yet.
+        </p>
       </div>
     </aside>
   </div>

--- a/src/app/games/cwg-2026-home.component.scss
+++ b/src/app/games/cwg-2026-home.component.scss
@@ -52,67 +52,491 @@ a {
 
 @import "./cwg-hero";
 
-.hero-stats {
+.hero-medal-tally {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 12px;
-  padding-top: 16px;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 10px;
+  padding: 14px;
+  overflow: hidden;
+  background:
+    linear-gradient(110deg, rgba(255, 153, 51, 0.055), transparent 32%),
+    linear-gradient(290deg, rgba(19, 136, 8, 0.055), transparent 32%),
+    rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 10px;
+  box-shadow: inset 3px 0 0 rgba(255, 153, 51, 0.72), inset -3px 0 0 rgba(19, 136, 8, 0.72);
 }
 
-.stat-box {
+.medal-tally-header {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.medal-tally-title {
+  display: grid;
   gap: 2px;
-  padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 8px;
+
+  > span {
+    color: rgba(247, 222, 160, 0.78);
+    font-family: "Geist Mono", monospace;
+    font-size: 0.63rem;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
 
   strong {
-    font-size: 1.3rem;
-    font-weight: 900;
     color: #ffffff;
+    font-size: 1rem;
+    font-weight: 900;
   }
 
-  span {
-    font-size: 0.72rem;
+  small {
     color: $muted;
+    font-size: 0.7rem;
   }
+}
 
-  &.gold strong {
-    color: $gold;
-  }
+.medal-tally-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
 
-  &.live-stat.has-live {
-    border-color: rgba(255, 107, 107, 0.28);
-    background: rgba(255, 107, 107, 0.08);
+.medal-stream-filter {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  background: rgba(0, 0, 0, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
 
-    strong {
-      color: $live;
+  button {
+    appearance: none;
+    padding: 6px 10px;
+    color: $muted;
+    font: 750 0.68rem/1 "Geist Sans", sans-serif;
+    white-space: nowrap;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: color 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+
+    &:hover,
+    &:focus-visible {
+      color: #ffffff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(217, 180, 65, 0.72);
+      outline-offset: 1px;
+    }
+
+    &.active {
+      color: #fff7dd;
+      background: rgba(217, 180, 65, 0.16);
+      border-color: rgba(217, 180, 65, 0.42);
     }
   }
 }
 
-.header-live-control {
+.medal-scoreboard {
+  display: grid;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+}
+
+.medal-scoreboard-head,
+.medal-scoreboard-row {
+  display: grid;
+  grid-template-columns: 66px minmax(150px, 1fr) repeat(4, minmax(70px, 0.36fr));
+  align-items: center;
+}
+
+.medal-scoreboard-head {
+  min-height: 31px;
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+
+  > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    padding: 7px 10px;
+    color: $muted;
+    font-family: "Geist Mono", monospace;
+    font-size: 0.61rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+
+    &:nth-child(2) {
+      justify-content: flex-start;
+    }
+  }
+}
+
+.medal-scoreboard-row {
+  min-height: 72px;
+}
+
+.india-rank {
+  display: grid;
+  align-self: stretch;
+  place-content: center;
+  gap: 2px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.025);
+  border-right: 1px solid rgba(255, 255, 255, 0.055);
+
+  > span {
+    color: #ffffff;
+    font-family: "Geist Mono", monospace;
+    font-size: 1.15rem;
+    font-weight: 950;
+    line-height: 1;
+  }
+
+  small {
+    color: rgba(255, 255, 255, 0.43);
+    font-size: 0.52rem;
+    font-weight: 750;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+}
+
+.medal-nation {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+  padding: 10px 12px;
+
+  > span:last-child {
+    display: grid;
+    gap: 1px;
+  }
+
+  strong {
+    color: #ffffff;
+    font-size: 0.88rem;
+    font-weight: 900;
+  }
+
+  small {
+    color: $muted;
+    font-family: "Geist Mono", monospace;
+    font-size: 0.62rem;
+    font-weight: 750;
+  }
+}
+
+.india-flag {
+  font-size: 1.65rem;
+  line-height: 1;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.28));
+}
+
+.medal-number {
+  display: flex;
+  align-self: stretch;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  color: #ffffff;
+  font-size: 1.55rem;
+  font-weight: 950;
+  line-height: 1;
+  border-left: 1px solid rgba(255, 255, 255, 0.055);
+
+  &.gold {
+    color: #f0ca54;
+  }
+
+  &.silver {
+    color: #d7e0ea;
+  }
+
+  &.bronze {
+    color: #e29a67;
+  }
+
+  &.total {
+    color: #ffffff;
+    background: rgba(141, 184, 255, 0.07);
+  }
+
+  img {
+    display: block;
+    width: 32px;
+    height: 39px;
+    flex: 0 0 auto;
+    object-fit: contain;
+    filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.45));
+  }
+}
+
+.medal-tally-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+
+  > span {
+    color: rgba(255, 255, 255, 0.46);
+    font-size: 0.64rem;
+  }
+}
+
+.medal-tally-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+}
+
+.medal-results-action {
   appearance: none;
-  width: 100%;
-  color: inherit;
-  font: inherit;
-  text-align: left;
+  min-height: 28px;
+  padding: 5px 10px;
+  color: $muted;
+  font: 800 0.65rem/1 "Geist Sans", sans-serif;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 999px;
   cursor: pointer;
-  transition: border-color 0.18s ease, background 0.18s ease;
+  transition: color 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
 
   &:hover,
   &:focus-visible {
+    color: #ffffff;
     border-color: rgba(255, 255, 255, 0.2);
-    background: rgba(255, 255, 255, 0.055);
+    background: rgba(255, 255, 255, 0.08);
   }
 
   &:focus-visible {
     outline: 2px solid rgba(217, 180, 65, 0.72);
     outline-offset: 2px;
   }
+
+  &.has-live {
+    color: #ffd5d5;
+    background: rgba(255, 107, 107, 0.1);
+    border-color: rgba(255, 107, 107, 0.32);
+  }
+}
+
+.medal-winners-action {
+  appearance: none;
+  min-height: 30px;
+  padding: 6px 11px;
+  color: #fff4c9;
+  font: 850 0.67rem/1 "Geist Sans", sans-serif;
+  background: rgba(217, 180, 65, 0.13);
+  border: 1px solid rgba(217, 180, 65, 0.34);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: #ffffff;
+    background: rgba(217, 180, 65, 0.22);
+    border-color: rgba(217, 180, 65, 0.55);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(217, 180, 65, 0.72);
+    outline-offset: 2px;
+  }
+}
+
+.medal-winners-panel {
+  max-width: 680px;
+}
+
+.medal-winners-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  > div {
+    display: grid;
+    gap: 2px;
+  }
+
+  strong {
+    color: #ffffff;
+    font-size: 0.94rem;
+    font-weight: 900;
+  }
+
+  small {
+    color: $muted;
+    font-size: 0.68rem;
+  }
+}
+
+.medal-winners-list {
+  display: grid;
+  gap: 8px;
+  height: 100%;
+  min-height: 0;
+  align-content: start;
+  padding-bottom: 8px;
+  overflow-y: auto;
+}
+
+.medal-sport-filters {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  gap: 6px;
+  padding: 2px 0 9px;
+  overflow-x: auto;
+  background: linear-gradient(180deg, #111117 72%, rgba(17, 17, 23, 0));
+  scrollbar-width: thin;
+
+  button {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex: 0 0 auto;
+    min-height: 30px;
+    padding: 5px 9px;
+    color: $muted;
+    font: 750 0.65rem/1 "Geist Sans", sans-serif;
+    white-space: nowrap;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 999px;
+    cursor: pointer;
+    transition: color 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+
+    strong {
+      display: grid;
+      min-width: 18px;
+      min-height: 18px;
+      place-items: center;
+      padding: 0 4px;
+      color: rgba(255, 255, 255, 0.74);
+      font-family: "Geist Mono", monospace;
+      font-size: 0.58rem;
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: 999px;
+    }
+
+    &:hover,
+    &:focus-visible {
+      color: #ffffff;
+      border-color: rgba(255, 255, 255, 0.2);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(217, 180, 65, 0.72);
+      outline-offset: 1px;
+    }
+
+    &.active {
+      color: #fff4c9;
+      background: rgba(217, 180, 65, 0.14);
+      border-color: rgba(217, 180, 65, 0.38);
+
+      strong {
+        color: #fff4c9;
+        background: rgba(217, 180, 65, 0.18);
+      }
+    }
+  }
+}
+
+.medal-winner-row {
+  appearance: none;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 9px 11px;
+  color: inherit;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: 9px;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+
+  > img {
+    display: block;
+    width: 34px;
+    height: 41px;
+    object-fit: contain;
+    filter: drop-shadow(0 3px 4px rgba(0, 0, 0, 0.42));
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(255, 255, 255, 0.065);
+    border-color: rgba(217, 180, 65, 0.28);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(217, 180, 65, 0.72);
+    outline-offset: 2px;
+  }
+}
+
+.medal-winner-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+
+  > span {
+    color: rgba(247, 222, 160, 0.76);
+    font-family: "Geist Mono", monospace;
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  strong {
+    overflow: hidden;
+    color: #ffffff;
+    font-size: 0.84rem;
+    font-weight: 900;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  small {
+    overflow: hidden;
+    color: $muted;
+    font-size: 0.69rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.medal-winners-empty {
+  padding: 28px 14px;
+  color: $muted;
+  font-size: 0.8rem;
+  text-align: center;
 }
 
 .header-results-container {
@@ -1714,6 +2138,10 @@ a {
   background: rgba(0, 0, 0, 0.66);
 }
 
+.result-session-dialog {
+  z-index: 1001;
+}
+
 .home-session-panel {
   box-sizing: border-box;
   width: min(520px, calc(100vw - 28px));
@@ -1735,6 +2163,45 @@ a {
   gap: 14px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   padding-bottom: 16px;
+}
+
+.home-session-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.home-dialog-back {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 6px 10px;
+  color: #fff4c9;
+  font: 800 0.68rem/1 "Geist Sans", sans-serif;
+  white-space: nowrap;
+  background: rgba(217, 180, 65, 0.11);
+  border: 1px solid rgba(217, 180, 65, 0.3);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease;
+
+  > span:first-child {
+    font-size: 1rem;
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(217, 180, 65, 0.2);
+    border-color: rgba(217, 180, 65, 0.52);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(217, 180, 65, 0.72);
+    outline-offset: 2px;
+  }
 }
 
 .home-dialog-close {
@@ -1932,22 +2399,76 @@ a {
 }
 
 @media (max-width: 768px) {
-  .hero-stats {
-    grid-template-columns: repeat(2, 1fr);
+  .medal-tally-header {
+    align-items: stretch;
+    flex-direction: column;
     gap: 10px;
   }
 
-  .stat-box {
-    padding: 10px;
+  .medal-tally-controls {
+    justify-content: stretch;
+  }
 
-    strong {
-      font-size: 1.25rem;
+  .medal-stream-filter {
+    flex: 1;
+
+    button {
+      flex: 1;
+    }
+  }
+
+  .medal-scoreboard-head,
+  .medal-scoreboard-row {
+    grid-template-columns: 38px minmax(76px, 1.25fr) repeat(4, minmax(36px, 0.58fr));
+  }
+
+  .medal-scoreboard-head > span {
+    gap: 4px;
+    padding: 7px 4px;
+    font-size: 0.55rem;
+  }
+
+  .medal-nation {
+    gap: 7px;
+    padding: 9px 8px;
+
+    .india-flag {
+      font-size: 1.35rem;
+    }
+  }
+
+  .medal-number {
+    gap: 4px;
+    font-size: 1.35rem;
+
+    img {
+      width: 20px;
+      height: 25px;
+    }
+  }
+
+  .india-rank {
+    > span {
+      font-size: 0.96rem;
     }
 
-    span {
-      font-size: 0.68rem;
-      line-height: 1.3;
+    small {
+      font-size: 0.44rem;
     }
+  }
+
+  .medal-tally-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .medal-tally-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .medal-winners-action {
+    margin-left: auto;
   }
 
   .matchup-line,
@@ -2045,6 +2566,16 @@ a {
   .home-session-dialog {
     align-items: flex-end;
     justify-content: stretch;
+  }
+
+  .home-session-header {
+    align-items: flex-start;
+  }
+
+  .home-session-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
   }
 
   .home-session-panel {

--- a/src/app/games/cwg-2026-home.component.ts
+++ b/src/app/games/cwg-2026-home.component.ts
@@ -5,6 +5,7 @@ import { PayloadService, Sport } from "../services/payload.service";
 import { Cwg2026ResultDetailComponent } from "./cwg-2026-result-detail.component";
 import {
   CWG_2026_GAMES_KEY,
+  CwgCompetitionStream,
   CwgGamesParticipation,
   CwgScheduleData,
   CwgScheduleRow,
@@ -50,6 +51,23 @@ interface TimelineGroup {
   hasMedal: boolean;
 }
 
+interface MedalTally {
+  gold: number;
+  silver: number;
+  bronze: number;
+  total: number;
+}
+
+interface MedalWinner {
+  id: string;
+  type: "gold" | "silver" | "bronze";
+  athleteName: string;
+  result?: string;
+  sport: string;
+  event: string;
+  row: CwgScheduleRow;
+}
+
 export interface WatchStory {
   rank: number;
   title: string;
@@ -93,6 +111,8 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
   private scheduleRequestInFlight = false;
 
   readonly medalIconUrl = "assets/images/cwg/glasgow-gold-medal.svg";
+  readonly silverMedalIconUrl = "assets/images/cwg/glasgow-silver-medal.svg";
+  readonly bronzeMedalIconUrl = "assets/images/cwg/glasgow-bronze-medal.svg";
   readonly glasgowLogoUrl = "assets/images/cwg/glasgow-2026-logo-vertical.svg";
   readonly participations = signal<CwgGamesParticipation[]>([]);
   readonly scheduleData = signal<CwgScheduleData>({
@@ -108,12 +128,115 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
   readonly hasRosterError = signal(false);
   readonly isScheduleLoading = signal(true);
   readonly hasScheduleError = signal(false);
+  readonly selectedMedalStream = signal<CwgCompetitionStream>("all");
+  readonly selectedMedalSport = signal<string>("all");
+  readonly indiaRank = signal<number | null>(8);
+  readonly isMedalWinnersDialogOpen = signal(false);
+  readonly resultOpenedFromMedalWinners = signal(false);
+  readonly medalStreamFilters: ReadonlyArray<{ key: CwgCompetitionStream; label: string }> = [
+    { key: "all", label: "All" },
+    { key: "able-bodied", label: "Able-bodied" },
+    { key: "para", label: "Para" },
+  ];
 
   readonly scheduleRows = computed(() =>
     [...this.scheduleData().rows].sort((a, b) => a.sortKey.localeCompare(b.sortKey)),
   );
 
   readonly activeScheduleRows = computed(() => this.scheduleRows().filter((row) => !row.isEliminated));
+
+  readonly medalTally = computed<MedalTally>(() => {
+    const selectedStream = this.selectedMedalStream();
+    const medalTypes = this.scheduleRows()
+      .filter((row) =>
+        selectedStream === "all"
+          ? true
+          : this.getScheduleCompetitionStream(row) === selectedStream,
+      )
+      .flatMap((row) => this.getResultMedalTypes(row));
+    const gold = medalTypes.filter((type) => type === "gold").length;
+    const silver = medalTypes.filter((type) => type === "silver").length;
+    const bronze = medalTypes.filter((type) => type === "bronze").length;
+
+    return {
+      gold,
+      silver,
+      bronze,
+      total: gold + silver + bronze,
+    };
+  });
+
+  readonly medalStreamLabel = computed(() => {
+    if (this.selectedMedalStream() === "able-bodied") return "Able-bodied";
+    if (this.selectedMedalStream() === "para") return "Para";
+    return "All events";
+  });
+
+  readonly medalWinners = computed<MedalWinner[]>(() => {
+    const selectedStream = this.selectedMedalStream();
+    const medalOrder = { gold: 0, silver: 1, bronze: 2 };
+
+    return this.scheduleRows()
+      .filter((row) => row.status === "completed" && Boolean(row.result))
+      .filter((row) =>
+        selectedStream === "all"
+          ? true
+          : this.getScheduleCompetitionStream(row) === selectedStream,
+      )
+      .flatMap((row) => {
+        const structuredMedals = row.result?.medals || [];
+        if (structuredMedals.length) {
+          return structuredMedals.map((medal, index) => ({
+            id: `${row.id}:${medal.type}:${medal.athleteName || index}`,
+            type: medal.type,
+            athleteName: medal.athleteName || row.athletes || "India",
+            result: medal.result,
+            sport: row.sport,
+            event: row.event,
+            row,
+          }));
+        }
+
+        const competitor = row.result?.match?.competitor1;
+        return this.getResultMedalTypes(row).map((type, index) => ({
+          id: `${row.id}:${type}:legacy-${index}`,
+          type,
+          athleteName: competitor?.name || row.athletes || "India",
+          result: competitor?.totalScore != null ? String(competitor.totalScore) : undefined,
+          sport: row.sport,
+          event: row.event,
+          row,
+        }));
+      })
+      .sort(
+        (a, b) =>
+          medalOrder[a.type] - medalOrder[b.type] ||
+          b.row.sortKey.localeCompare(a.row.sortKey) ||
+          a.athleteName.localeCompare(b.athleteName),
+      );
+  });
+
+  readonly medalSportFilters = computed(() => {
+    const counts = new Map<string, number>();
+    this.medalWinners().forEach((winner) => {
+      counts.set(winner.sport, (counts.get(winner.sport) || 0) + 1);
+    });
+
+    return [
+      { key: "all", label: "All sports", count: this.medalWinners().length },
+      ...[...counts.entries()]
+        .sort(([leftSport, leftCount], [rightSport, rightCount]) =>
+          rightCount - leftCount || leftSport.localeCompare(rightSport),
+        )
+        .map(([sport, count]) => ({ key: sport, label: sport, count })),
+    ];
+  });
+
+  readonly visibleMedalWinners = computed(() => {
+    const selectedSport = this.selectedMedalSport();
+    if (selectedSport === "all") return this.medalWinners();
+    return this.medalWinners().filter((winner) => winner.sport === selectedSport);
+  });
 
   readonly declaredResults = computed(() =>
     this.activeScheduleRows()
@@ -133,26 +256,6 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
       .filter((item) => Boolean(item && item.row && item.row.id))
       .slice(0, 2),
   );
-
-  readonly summary = computed(() => {
-    const roster = this.participations();
-    const scheduleRows = this.scheduleRows();
-    const ableRows = roster.filter((row) => row.competitionStream === "able-bodied");
-    const paraRows = roster.filter((row) => row.competitionStream === "para");
-
-    const goldsCount = new Set(scheduleRows.flatMap((row) => row.goldMedalEvents || [])).size;
-
-    return {
-      athletes: roster.length || 126,
-      ableAthletes: ableRows.length || 97,
-      paraAthletes: paraRows.length || 29,
-      sports: new Set(roster.map((row) => getParticipationSportName(row))).size || 13,
-      ableSports: new Set(ableRows.map((row) => getParticipationSportName(row))).size || 8,
-      paraSports: new Set(paraRows.map((row) => getParticipationSportName(row))).size || 5,
-      scheduleEntries: scheduleRows.length || 204,
-      golds: goldsCount || 108,
-    };
-  });
 
   readonly watchGroups = computed(() => {
     const groups = new Map<string, WatchGroup>();
@@ -256,7 +359,6 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
     const now = this.now().getTime();
     const rows = this.activeScheduleRows()
       .filter((row) => this.isOperationalUpcomingRow(row, now))
-      .filter((row) => row.id !== this.nextIndiaSession()?.id)
       .sort((a, b) => this.compareTimelineRows(a, b));
     const groupsMap = new Map<string, ScheduleDateGroup>();
 
@@ -300,7 +402,6 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
       const next24Hours = now + 24 * 60 * 60 * 1000;
       const upcoming = this.activeScheduleRows()
         .filter((row) => this.isOperationalUpcomingRow(row, now))
-        .filter((row) => row.id !== this.nextIndiaSession()?.id)
         .sort((a, b) => this.compareTimelineRows(a, b));
       const nextDayRows = upcoming.filter((row) => this.getSessionStartMs(row) < next24Hours);
       return nextDayRows.length ? nextDayRows : upcoming;
@@ -318,12 +419,43 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
     return this.activeScheduleRows()
       .filter((row) => this.isMedalRow(row))
       .filter((row) => this.isOperationalUpcomingRow(row, now))
-      .filter((row) => row.id !== this.nextIndiaSession()?.id)
       .sort((a, b) => this.compareTimelineRows(a, b));
   });
 
   setSelectedDateKey(key: string): void {
     this.selectedDateKey.set(key);
+  }
+
+  setMedalStream(stream: CwgCompetitionStream): void {
+    this.selectedMedalStream.set(stream);
+    this.selectedMedalSport.set("all");
+  }
+
+  setMedalSport(sport: string): void {
+    this.selectedMedalSport.set(sport);
+  }
+
+  getMedalIconUrl(type: "gold" | "silver" | "bronze"): string {
+    if (type === "silver") return this.silverMedalIconUrl;
+    if (type === "bronze") return this.bronzeMedalIconUrl;
+    return this.medalIconUrl;
+  }
+
+  getMedalLabel(type: "gold" | "silver" | "bronze"): string {
+    return `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
+  }
+
+  openMedalWinnersDialog(): void {
+    this.isMedalWinnersDialogOpen.set(true);
+  }
+
+  closeMedalWinnersDialog(): void {
+    this.isMedalWinnersDialogOpen.set(false);
+  }
+
+  openMedalWinnerDetails(winner: MedalWinner): void {
+    this.resultOpenedFromMedalWinners.set(true);
+    this.selectedSessionRow.set(winner.row);
   }
 
   ngOnInit(): void {
@@ -345,6 +477,13 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
         this.participations.set([]);
         this.isRosterLoading.set(false);
         this.hasRosterError.set(true);
+      },
+    });
+
+    this.payload.getEditionBySlug("glasgow-2026").subscribe({
+      next: (edition) => {
+        const rank = edition?.globalStats?.indiaRank;
+        if (typeof rank === "number" && rank > 0) this.indiaRank.set(rank);
       },
     });
 
@@ -612,9 +751,10 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
   }
 
   private getSessionEndMs(row: CwgScheduleRow): number {
+    const start = this.getSessionStartMs(row);
     const timestamp = parseCwgScheduleTimestamp(row.istEnd);
-    if (Number.isFinite(timestamp)) return timestamp;
-    return this.getSessionStartMs(row) + 2 * 60 * 60 * 1000;
+    if (Number.isFinite(timestamp) && timestamp > start) return timestamp;
+    return start + 2 * 60 * 60 * 1000;
   }
 
   private isDeclaredResultRow(row: CwgScheduleRow): boolean {
@@ -740,6 +880,49 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
     return row.isMedalSession || Boolean(row.goldMedalEvents?.length);
   }
 
+  private getScheduleCompetitionStream(row: CwgScheduleRow): Exclude<CwgCompetitionStream, "all"> {
+    if (row.competitionStream) return row.competitionStream;
+
+    const sportLabel = `${row.sport || ""} ${row.sportSlug || ""}`.toLowerCase();
+    return sportLabel.includes("para") || sportLabel.includes("wheelchair")
+      ? "para"
+      : "able-bodied";
+  }
+
+  private getResultMedalTypes(row: CwgScheduleRow): Array<"gold" | "silver" | "bronze"> {
+    if (row.status !== "completed" || !row.result) return [];
+
+    const structuredMedals = (row.result.medals || [])
+      .map((medal) => medal.type)
+      .filter(
+        (type): type is "gold" | "silver" | "bronze" =>
+          type === "gold" || type === "silver" || type === "bronze",
+      );
+    if (structuredMedals.length) return structuredMedals;
+
+    const resultLabels = [
+      row.result.summaryLabel,
+      row.result.resultLabel,
+      row.result.summary,
+      row.result.outcome,
+    ]
+      .filter(Boolean)
+      .map((label) => String(label).trim().toLowerCase());
+
+    return (["gold", "silver", "bronze"] as const).filter((type) =>
+      resultLabels.some(
+        (label) =>
+          label === type ||
+          label === `${type} medal` ||
+          label.startsWith(`${type} ·`) ||
+          label.startsWith(`${type} (`) ||
+          label.startsWith(`${type} medal ·`) ||
+          label === `won ${type}` ||
+          label.startsWith(`won ${type} ·`),
+      ),
+    );
+  }
+
   private normalizeSportKey(value?: string | null): string {
     return (value || "")
       .toLowerCase()
@@ -848,11 +1031,18 @@ export class Cwg2026HomeComponent implements OnInit, OnDestroy {
   }
 
   openSessionDialog(row: CwgScheduleRow): void {
+    this.resultOpenedFromMedalWinners.set(false);
     this.selectedSessionRow.set(row);
   }
 
   closeSessionDialog(): void {
     this.selectedSessionRow.set(null);
+    this.resultOpenedFromMedalWinners.set(false);
+  }
+
+  backToMedalWinners(): void {
+    this.selectedSessionRow.set(null);
+    this.resultOpenedFromMedalWinners.set(false);
   }
 
   openHeaderLivePanel(): void {

--- a/src/app/games/cwg-2026-hub.component.ts
+++ b/src/app/games/cwg-2026-hub.component.ts
@@ -113,7 +113,7 @@ export class Cwg2026HubComponent implements OnInit, OnDestroy {
 
   readonly streamTabs = computed(() =>
     this.streamOptions.map((stream) => {
-      const rows = this.rowsForStream(stream.key);
+      const rows = this.remainingRowsForStream(stream.key);
       return {
         ...stream,
         rows: rows.length,
@@ -166,10 +166,7 @@ export class Cwg2026HubComponent implements OnInit, OnDestroy {
           return this.getSessionStartMs(a) - this.getSessionStartMs(b);
         });
     }
-    const now = this.now().getTime();
-    return rows
-      .filter((row) => this.isOperationalMatrixRow(row, now))
-      .sort((a, b) => this.getSessionStartMs(a) - this.getSessionStartMs(b));
+    return this.remainingRowsForStream(stream);
   }
 
   readonly matrixRows = computed(() => this.buildMatrixRows(this.visibleRows()));
@@ -464,6 +461,13 @@ export class Cwg2026HubComponent implements OnInit, OnDestroy {
     return rows.filter((row) => this.getScheduleStream(row) === stream);
   }
 
+  private remainingRowsForStream(stream: CompetitionStream): CwgScheduleRow[] {
+    const now = this.now().getTime();
+    return this.rowsForStream(stream)
+      .filter((row) => this.isOperationalMatrixRow(row, now))
+      .sort((a, b) => this.getSessionStartMs(a) - this.getSessionStartMs(b));
+  }
+
   private isDeclaredResultRow(row: CwgScheduleRow): boolean {
     return row.status === "completed" || Boolean(getScheduleResultSummary(row));
   }
@@ -479,9 +483,10 @@ export class Cwg2026HubComponent implements OnInit, OnDestroy {
   }
 
   private getSessionEndMs(row: CwgScheduleRow): number {
+    const start = this.getSessionStartMs(row);
     const timestamp = parseCwgScheduleTimestamp(row.istEnd);
-    if (Number.isFinite(timestamp)) return timestamp;
-    return this.getSessionStartMs(row) + 2 * 60 * 60 * 1000;
+    if (Number.isFinite(timestamp) && timestamp > start) return timestamp;
+    return start + 2 * 60 * 60 * 1000;
   }
 
   private countGoldMedalEvents(rows: CwgScheduleRow[]): number {

--- a/src/app/games/cwg-2026-result-detail.component.ts
+++ b/src/app/games/cwg-2026-result-detail.component.ts
@@ -173,11 +173,22 @@ export class Cwg2026ResultDetailComponent {
   }
 
   get officialIndiaEntries(): CwgOfficialResultEntry[] {
-    if (!this.isGymnasticsAllAround) return this.rawOfficialIndiaEntries;
-    const overallEntries = this.rawOfficialIndiaEntries.filter(
-      (entry) => entry.bucket === "overall",
-    );
-    return overallEntries.length ? overallEntries : this.rawOfficialIndiaEntries;
+    const entries = this.isGymnasticsAllAround
+      ? this.rawOfficialIndiaEntries.filter((entry) => entry.bucket === "overall")
+      : this.rawOfficialIndiaEntries;
+    const displayEntries = entries.length ? entries : this.rawOfficialIndiaEntries;
+
+    return [...displayEntries].sort((left, right) => {
+      const leftRank = Number(left.rank);
+      const rightRank = Number(right.rank);
+      const leftHasRank = Number.isFinite(leftRank) && leftRank > 0;
+      const rightHasRank = Number.isFinite(rightRank) && rightRank > 0;
+
+      if (leftHasRank && rightHasRank) return leftRank - rightRank;
+      if (leftHasRank) return -1;
+      if (rightHasRank) return 1;
+      return 0;
+    });
   }
 
   get hasDetailedResult(): boolean {

--- a/src/app/games/cwg-2026.types.ts
+++ b/src/app/games/cwg-2026.types.ts
@@ -41,6 +41,7 @@ export interface CwgScheduleRow {
   localTimeLabel?: string;
   sport: string;
   sportSlug: string;
+  competitionStream?: Exclude<CwgCompetitionStream, "all">;
   event: string;
   stage: string;
   phase?: string;
@@ -351,10 +352,13 @@ export const isScheduleRowLiveNow = (row: CwgScheduleRow, now = new Date()): boo
   if (!row.istStart) return false;
   const start = parseCwgScheduleTimestamp(row.istStart);
   const parsedEnd = parseCwgScheduleTimestamp(row.istEnd);
-  const end = Number.isFinite(parsedEnd) ? parsedEnd : start + 2 * 60 * 60 * 1000;
+  const end =
+    Number.isFinite(parsedEnd) && parsedEnd > start
+      ? parsedEnd
+      : start + 2 * 60 * 60 * 1000;
   const isBoxing = `${row.sportSlug} ${row.sport}`.toLowerCase().includes('boxing');
   // Bout times are estimates; keep boxing visible while the official result catches up.
-  const resultGraceMs = isBoxing ? 20 * 60 * 1000 : 0;
+  const resultGraceMs = isBoxing ? 5 * 60 * 1000 : 0;
   const current = now.getTime();
   return current >= start && current <= end + resultGraceMs;
 };

--- a/src/assets/images/cwg/glasgow-silver-medal.svg
+++ b/src/assets/images/cwg/glasgow-silver-medal.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240" width="200" height="240">
+  <defs>
+    <!-- Premium Shimmer Silver Gradients -->
+    <linearGradient id="silver-bevel" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="20%" stop-color="#DDE4EA"/>
+      <stop offset="45%" stop-color="#8A949E"/>
+      <stop offset="70%" stop-color="#F2F5F7"/>
+      <stop offset="90%" stop-color="#69737C"/>
+      <stop offset="100%" stop-color="#3E464D"/>
+    </linearGradient>
+
+    <linearGradient id="silver-surface" x1="10%" y1="5%" x2="90%" y2="95%">
+      <stop offset="0%" stop-color="#F7FAFC"/>
+      <stop offset="30%" stop-color="#C7D0D8"/>
+      <stop offset="65%" stop-color="#929DA7"/>
+      <stop offset="100%" stop-color="#E2E8ED"/>
+    </linearGradient>
+
+    <linearGradient id="silver-lattice" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5C6670"/>
+      <stop offset="50%" stop-color="#3E474F"/>
+      <stop offset="100%" stop-color="#20262B"/>
+    </linearGradient>
+
+    <!-- Deep Blue Ribbon Gradient -->
+    <linearGradient id="blue-ribbon-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0E2447"/>
+      <stop offset="30%" stop-color="#1E4785"/>
+      <stop offset="60%" stop-color="#2B5CA0"/>
+      <stop offset="85%" stop-color="#163668"/>
+      <stop offset="100%" stop-color="#0B1A33"/>
+    </linearGradient>
+
+    <!-- High Contrast Emboss Drop Shadow -->
+    <filter id="emboss-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="1" flood-color="#FFFFFF" flood-opacity="0.6" result="highlight"/>
+      <feDropShadow dx="0" dy="-1.5" stdDeviation="1" flood-color="#000000" flood-opacity="0.7"/>
+    </filter>
+
+    <filter id="medal-drop-shadow" x="-15%" y="-15%" width="130%" height="130%">
+      <feDropShadow dx="0" dy="5" stdDeviation="6" flood-color="#000000" flood-opacity="0.6"/>
+    </filter>
+  </defs>
+
+  <!-- Blue Woven Ribbon with White Chevron Emblem -->
+  <g class="ribbon-assembly">
+    <!-- Ribbon Base Shape -->
+    <path d="M 74 0 L 63 70 L 137 70 L 126 0 Z" fill="url(#blue-ribbon-grad)"/>
+
+    <!-- Ribbon Weave Texture -->
+    <path d="M 68 0 L 60 70 M 76 0 L 70 70 M 84 0 L 80 70 M 92 0 L 90 70 M 100 0 L 100 70 M 108 0 L 110 70 M 116 0 L 120 70 M 124 0 L 130 70"
+          stroke="rgba(255,255,255,0.14)" stroke-width="1.8"/>
+
+    <!-- Bold White Chevron Mark on Ribbon -->
+    <g transform="translate(100, 35) scale(0.65)" stroke="#FFFFFF" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M-22,-10 L-11,7 L0,-10 L11,7 L22,-10"/>
+      <path d="M-13,-10 L0,9 L13,-10"/>
+    </g>
+  </g>
+
+  <!-- Solid Metal Loop Attachment -->
+  <path d="M 66 62 C 66 54 134 54 134 62 L 138 72 C 138 76 62 76 62 72 Z" fill="url(#silver-bevel)" stroke="#3E474F" stroke-width="0.8"/>
+
+  <!-- Medal Shield Outer Body -->
+  <g filter="url(#medal-drop-shadow)">
+    <!-- Outer Metallic Bevel Rim -->
+    <path d="M 36 74 Q 100 64 164 74 Q 176 146 100 234 Q 24 146 36 74 Z" fill="url(#silver-bevel)" stroke="#343C43" stroke-width="1.5"/>
+
+    <!-- Inner Medal Face Plate -->
+    <path d="M 42 78 Q 100 70 158 78 Q 168 142 100 226 Q 32 142 42 78 Z" fill="url(#silver-surface)"/>
+
+    <!-- Left Clyde Bridge Lattice Girder Grid (Sharp & Bold) -->
+    <g opacity="0.6" stroke="url(#silver-lattice)" stroke-width="1.8" stroke-linecap="round" fill="none">
+      <!-- Outer Boundary Curve of Left Lattice Strip -->
+      <path d="M 46 82 Q 72 76 89 82 Q 97 148 78 200 Q 41 148 46 82 Z" stroke-width="2"/>
+
+      <!-- Crosshatch Diagonals -->
+      <line x1="48" y1="88" x2="87" y2="103"/>
+      <line x1="50" y1="108" x2="89" y2="123"/>
+      <line x1="53" y1="128" x2="87" y2="143"/>
+      <line x1="56" y1="148" x2="83" y2="163"/>
+      <line x1="60" y1="168" x2="78" y2="183"/>
+
+      <line x1="85" y1="88" x2="50" y2="103"/>
+      <line x1="88" y1="108" x2="52" y2="123"/>
+      <line x1="87" y1="128" x2="54" y2="143"/>
+      <line x1="83" y1="148" x2="58" y2="163"/>
+      <line x1="78" y1="168" x2="62" y2="183"/>
+
+      <!-- Central Structural Divider -->
+      <path d="M 67 80 Q 79 138 69 192" stroke-width="1.6"/>
+    </g>
+
+    <!-- Right Side Glasgow 2026 Official Logo & Ultra-Readable Text -->
+    <g transform="translate(126, 102)" text-anchor="middle">
+      <!-- Glasgow Chevron Emblem (Bold Dark Bronze Fill & Stroke) -->
+      <g stroke="#1C252C" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M-24,-22 L-16,0 L-8,-22 L0,0 L8,-22 L16,0 L24,-22" stroke-width="4.5"/>
+        <path d="M-16,-22 L0,2 L16,-22" stroke-width="3.8"/>
+        <path d="M-8,-22 L0,-6 L8,-22" stroke-width="3.2"/>
+      </g>
+
+      <!-- COMMONWEALTH (Ultra-Crisp Bold Engraved Text) -->
+      <text x="0" y="16"
+            font-family="'Geist Sans', system-ui, -apple-system, sans-serif"
+            font-size="11"
+            font-weight="900"
+            letter-spacing="0.6"
+            fill="#1C252C"
+            stroke="#1C252C"
+            stroke-width="0.5">COMMONWEALTH</text>
+
+      <!-- GAMES -->
+      <text x="0" y="29"
+            font-family="'Geist Sans', system-ui, -apple-system, sans-serif"
+            font-size="12"
+            font-weight="900"
+            letter-spacing="1.2"
+            fill="#1C252C"
+            stroke="#1C252C"
+            stroke-width="0.6">GAMES</text>
+
+      <!-- GLASGOW 2026 -->
+      <text x="0" y="43"
+            font-family="'Geist Sans', system-ui, -apple-system, sans-serif"
+            font-size="10"
+            font-weight="950"
+            letter-spacing="1.4"
+            fill="#182027"
+            stroke="#182027"
+            stroke-width="0.7">GLASGOW 2026</text>
+    </g>
+
+    <!-- Metallic Edge Light Highlights -->
+    <path d="M 42 78 Q 100 70 158 78" stroke="rgba(255,255,255,0.85)" stroke-width="2.5" fill="none"/>
+    <path d="M 158 78 Q 168 142 100 226" stroke="rgba(40,48,55,0.5)" stroke-width="2.5" fill="none"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- replace the legacy hero statistics with India’s medal tally and overall rank
- add able-bodied/para filters plus medal-winner sport filters and result navigation
- use official gold, silver, and bronze medal artwork
- correct ranked-result ordering, timeline counts, end-time fallback, and live grace handling
- update the frontend version to 3.0.8

## Validation
- `tsc -p tsconfig.app.json --noEmit`
- Angular template compilation with `ngc -p tsconfig.app.json`
- browser QA for tally counts, filters, winner details/back navigation, sorted sport chips, and desktop drawer sizing
- local `ng build` is blocked by the workstation’s unsupported Node 24 runtime; deployment CI uses Node 20

## Release coordination
Merge after backend PR `Indian-Olympic-Dream/iod-content#2`; deploy only after the backend and database synchronization are verified.